### PR TITLE
Fixed shadowing attrs core fns

### DIFF
--- a/src/dev/onionpancakes/chassis/compiler.clj
+++ b/src/dev/onionpancakes/chassis/compiler.clj
@@ -111,9 +111,11 @@
     #'clojure.core/update-vals})
 
 (defn attrs-invocation?
-  [[sym & _]]
-  (and (symbol? sym)
-       (contains? attrs-invocable-vars (resolve sym))))
+  [[sym & _ :as this]]
+  (and (seq? this)
+       (symbol? sym)
+       (bound? #'*env*)
+       (contains? attrs-invocable-vars (resolve *env* sym))))
 
 (defn attrs-type?
   [clazz]

--- a/test/dev/onionpancakes/chassis/tests/test_compiler.clj
+++ b/test/dev/onionpancakes/chassis/tests/test_compiler.clj
@@ -212,6 +212,14 @@
   (doseq [[elem warning] @ambig-attrs-warnings]
     (is false (str "Ambig attrs with elem: " elem))))
 
+(deftest test-compile-shadow-attrs-core-fns
+  (let [assoc (fn [& _] "assoc-shadowed")
+        merge (fn [& _] "merge-shadowed")]
+    (is (= (c/html (cc/compile [:div (assoc {} :foo :bar)]))
+           "<div>assoc-shadowed</div>"))
+    (is (= (c/html (cc/compile [:div (merge {} {:foo :bar})]))
+           "<div>merge-shadowed</div>"))))
+
 ;; Alias
 
 (defmethod c/resolve-alias ::TestAliasContent


### PR DESCRIPTION
Fixed case where you can shadow an attrs core function into something that does not return a map.