### PR TITLE
Extend string and numbers directly instead of through Constable

### DIFF
--- a/src/dev/onionpancakes/chassis/compiler.clj
+++ b/src/dev/onionpancakes/chassis/compiler.clj
@@ -273,9 +273,61 @@
         ;; Works for now...
         (if (constant? val) val this))
       this))
-  ;; Constable catches Strings, constant Numbers
-  ;; (not mutable accumulator Numbers), and a bit more.
-  java.lang.constant.Constable
+  String
+  (attrs? [_] false)
+  (not-attrs? [_] true)
+  (constant? [_] true)
+  (evaluated? [_] true)
+  (resolved [this] this)
+  Short
+  (attrs? [_] false)
+  (not-attrs? [_] true)
+  (constant? [_] true)
+  (evaluated? [_] true)
+  (resolved [this] this)
+  Integer
+  (attrs? [_] false)
+  (not-attrs? [_] true)
+  (constant? [_] true)
+  (evaluated? [_] true)
+  (resolved [this] this)
+  Long
+  (attrs? [_] false)
+  (not-attrs? [_] true)
+  (constant? [_] true)
+  (evaluated? [_] true)
+  (resolved [this] this)
+  BigInteger
+  (attrs? [_] false)
+  (not-attrs? [_] true)
+  (constant? [_] true)
+  (evaluated? [_] true)
+  (resolved [this] this)
+  Float
+  (attrs? [_] false)
+  (not-attrs? [_] true)
+  (constant? [_] true)
+  (evaluated? [_] true)
+  (resolved [this] this)
+  Double
+  (attrs? [_] false)
+  (not-attrs? [_] true)
+  (constant? [_] true)
+  (evaluated? [_] true)
+  (resolved [this] this)
+  BigDecimal
+  (attrs? [_] false)
+  (not-attrs? [_] true)
+  (constant? [_] true)
+  (evaluated? [_] true)
+  (resolved [this] this)
+  clojure.lang.BigInt
+  (attrs? [_] false)
+  (not-attrs? [_] true)
+  (constant? [_] true)
+  (evaluated? [_] true)
+  (resolved [this] this)
+  clojure.lang.Ratio
   (attrs? [_] false)
   (not-attrs? [_] true)
   (constant? [_] true)

--- a/test/dev/onionpancakes/chassis/tests/test_compiler.clj
+++ b/test/dev/onionpancakes/chassis/tests/test_compiler.clj
@@ -134,6 +134,11 @@
                 (and (instance? dev.onionpancakes.chassis.core.RawString ret)
                      (= (c/fragment ret) (c/html node))))
     nil
+    0
+    0N
+    0.0
+    0.0M
+    3/2
     ""
     [:div]
     [:div#foo.bar "123"]
@@ -142,6 +147,51 @@
     [:div [1 2 3 4]]
     [:div #{1 2 3 4}]
 
+    ;; Macros
+    (example-elem-macro "123")
+    (example-elem-macro-nested "123")
+    [:div [:p "foo"] (example-elem-macro "123") [:p "bar"]]
+    [:div [:p "foo"] (example-elem-macro-nested "123") [:p "bar"]]
+
+    ;; Var consts
+    [:div {:foo example-constant}]
+    [c/doctype-html5 [:div "foo" c/nbsp "bar"]]))
+
+(deftest test-compile-node-full-compaction
+  (are [node] (let [ret (cc/compile-node node)]
+                (and (instance? dev.onionpancakes.chassis.core.RawString ret)
+                     (= (c/fragment ret) (c/html node))))
+    nil
+    0
+    0N
+    0.0
+    0.0M
+    3/2
+    ""
+    (short 0)
+    (int 0)
+    (long 0)
+    (bigint 0)
+    (biginteger 0)
+    (float 0)
+    (double 0)
+    (bigdec 0)
+    
+    [:div]
+    [:div#foo.bar "123"]
+    [:div {:foo "bar"} "123"]
+    [:div [:p "foo"] [:p "bar"]]
+    [:div [1 2 3 4]]
+    [:div #{1 2 3 4}]
+
+    ;; Alias
+    [::Foo]
+    [::Foo nil "foo"]
+
+    ;; Fns
+    (example-elem-fn "123")
+    [:div (example-elem-fn "123")]
+    
     ;; Macros
     (example-elem-macro "123")
     (example-elem-macro-nested "123")


### PR DESCRIPTION
Extend string and numbers directly instead of through java.lang.constant.Constable.

- The java.lang.constant is package for constant optimizations with javac, which is not relevant for Clojure.
- java.lang.constant requires Java 12. Removing this allows targeting lower Java versions.
- In addition, also extend constant Clojure numeric types BigInt and Ratio.